### PR TITLE
Add graph-store docs.

### DIFF
--- a/docs/doc/inc/garden/dev/graph-store/advanced-info.udon
+++ b/docs/doc/inc/garden/dev/graph-store/advanced-info.udon
@@ -1,0 +1,58 @@
+;>
+
+This section is not required, but does shed light on some implicit assumptions that Graph Store makes.
+
+
+### Miscellaneous
+- Only nodes that successfully typecheck under the validator will be added to the graph
+- Graphs are validated recursively (see [`app/graph-store.hoon#L598-L616`](https://github.com/urbit/urbit/blob/5cb6af0433a65fb28b4bc957be10cb436781392d/pkg/arvo/app/graph-store.hoon#L598-L616))
+  - First, validate all top level nodes of a graph.
+  - Then, recursively validate all children nodes of those nodes.
+  - Base case: empty children is always valid
+- Nodes are also validated against the graph's mark when inserted individually (see [`app/graph-store.hoon#L380`](https://github.com/urbit/urbit/blob/e2ad6e3e9219c8bfad62f27f05c7cac94c9effa8/pkg/arvo/app/graph-store.hoon#L380))
+- Only the root level graphs get validated with marks. There is only one mark / validator per graph. All child graphs get validated with the same mark as the root/top-level one.
+- The way in which Graph Store works is by mirroring all data from a given social media channel. Thus, anything you see is your copy of it, and anything you do is sent as a request to the hosting ship.
+- Unmanaged graphs (a graph that isn't associated to a group) actually still have a unmanaged / hidden group. If you want to construct a `reference` to content in an unmanaged graph, it is still possible; the group in that case is then the same resource id as the graph itself
+
+
+
+### What happens when you add or remove a node?
+
+When adding nodes, Graph Store takes in a `(map index node)`. That is, a map of `node`s to add keyed by an `index` representing where in the graph the node should be inserted. However, there are some limitations. For instance, Graph Store does not allow for a `node` which has non-existent ancestors to be added, meaning that missing ancestor nodes are not automatically created. Graph Store requires that every node up until the 2nd to last level of nesting is created, meaning that every ancestor except the parent must be created before being added. The ancestors must either already exist in Graph Store or must be included in the `graph-update`. To ensure consistent behavior, all nodes are added shallowest-index first, which ensures that no child is added before it's parent (if it exists). This is why any non-leaf node must have its parent exist, either already within the graph or in the update. 
+
+Also, Graph Store merges the flat list of nodes from an `%add-nodes` update into the fully connected graph structure. This means that when sending an update to `graph-store`, children nodes do not have to be nested within the parent's data structure in the update. They simply have to exist somewhere in the update.
+
+Another constraint to be aware of is that in a map of indexed nodes: for each node, the index in map entry has to be the same index as the in that `node`'s post index.
+
+To see how Graph Store handles add-nodes, take a look at [`app/graph-store.hoon#L370-L417`](https://github.com/urbit/urbit/blob/e2ad6e3e9219c8bfad62f27f05c7cac94c9effa8/pkg/arvo/app/graph-store.hoon#L370-L417).
+
+
+### Permissions internals
+Internally, the permissions part of a mark (the grow arm) are built and then watched for changes by Graph Store. See [`app/graph-push-hook.hoon#L154`](https://github.com/urbit/urbit/blob/ac096d85ae847fcfe8786b51039c92c69abc006e/pkg/arvo/app/graph-push-hook.hoon#L154) for more info.
+
+It is important to note that the push hook and permissions system is bespoke, and doesn't necessarily fit all permissions schemes out there. In addition, the permissions structure is likely to change, so it can make sense to implement your own permissioning structure (if you are not using `graph-push-hook`), especially in the case where you are making your own resource control system.
+The `graph-push-hook` permissions system is not the definite way to implement permissions, and is simply one pre-existing way to do it.
+The validator mark doesn't need any permissions to compile; it just needs a grow arm with at least `noun`.
+The way to implement your own permissioning structure is in the form of your own grow arm definitions in the validator.
+There's nothing special about the `graph-permission-add` arms; they are just constants, arms which are known to push-hook.
+As stated before, Graph Store proper (`app/graph-store.hoon`) doesn't know anything about the permissions.
+
+
+
+
+### Push Hook Details
+
+As a result of the hook architecture, all hooks have the ability to transform incoming data before it is accepted and trusted as a local input.
+Graph Push Hook is no exception. This is why the `transform-add-nodes` is required for every validator; Graph Store calls this function before adding any nodes to itself.
+Right now, the only thing that `transform-add-nodes` is used for is to replace untrusted foreign timestamps with trusted local timestamps.
+
+Here is a stubbed out example of a `transform-add-nodes` to show its inputs and outputs:
+
+```hoon
+|=  [=index =post =atom was-parent-modified=?]
+^-  [^index ^post]
+!!
+```
+
+The simplest transformer can simply return the exact same indexed post, which would mean that it would trust all foreign `index`es and `post`s by default.
+The atom is always `now.bowl`, i.e. what the datetime on us, the receiving side is.

--- a/docs/doc/inc/garden/dev/graph-store/data-structure-overview.udon
+++ b/docs/doc/inc/garden/dev/graph-store/data-structure-overview.udon
@@ -1,0 +1,342 @@
+;>
+
+Let's go through the type definitions of some of the most used types when working with Graph Store.
+
+## Post
+
+Here's `sur/post.hoon`
+
+```hoon
++$  index       (list atom)
++$  uid         [=resource =index]
+::
+::  +sham (half sha-256) hash of +validated-portion
++$  hash  @ux
+::
++$  signature   [p=@ux q=ship r=life]
++$  signatures  (set signature)
++$  post
+  $:  author=ship
+      =index
+      time-sent=time
+      contents=(list content)
+      hash=(unit hash)
+      =signatures
+  ==
+::
++$  indexed-post  [a=atom p=post]
+::
++$  validated-portion
+  $:  parent-hash=(unit hash)
+      author=ship
+      time-sent=time
+      contents=(list content)
+  ==
+::
++$  reference
+  $%  [%graph group=resource =uid]
+      [%group group=resource]
+      [%app =ship =desk =path]
+  ==
+::
++$  content
+  $%  [%text text=cord]
+      [%mention =ship]
+      [%url url=cord]
+      [%code expression=cord output=(list tank)]
+      [%reference =reference]
+  ==
+```
+
+### Index
+
+```hoon
++$  index       (list atom)
++$  uid         [=resource =index]
+```
+
+`index` is a list of atoms (big integers). It represents a path to a specific node on a graph that is nested arbitrarily deep.
+
+`uid` is simply a pair of a `resource` and an `index`. These two pieces of information combine to form an unambiguous way to identify and reference a node. It is used in the `content` type to model a reference.
+
+An index fragment is not an explicitly defined type, but since an index is `(list atom)`, it follows that the type of an index fragment is `atom`. This is what gives the developer the flexibility to use more than just numbers in an index: any type that is representable as an atom can be used in the index.
+
+### Hashing (Part 1)
+
+```hoon
+::  +sham (half sha-256) hash of +validated-portion
++$  hash  @ux
+::
++$  signature   [p=@ux q=ship r=life]
++$  signatures  (set signature)
+```
+
+These types are used to cryptographically sign a given post, so that the host of some content cannot act as an imposter, and post content impersonating as someone else. `signature` represents a triple of signed message of hash, author, and author's life at time of posting. These can be used to cryptographically attest to a message. The implementation is a form of asymmetric/public-key encryption, where `q` and `r` are data necessary to look up a ship's public key on azimuth, which can be used to verify the validity of the message.
+
+### Content Types
+
+```hoon
++$  reference
+  $%  [%graph group=resource =uid]
+      [%group group=resource]
+      [%app =ship =desk =path]
+  ==
+::
++$  content
+  $%  [%text text=cord]
+      [%mention =ship]
+      [%url url=cord]
+      [%code expression=cord output=(list tank)]
+      [%reference =reference]
+  ==
+::
+```
+
+`reference` is a type that models a reference to a graph object.
+
+- `%graph` is a reference to a specific node in a given graph identified by its resource
+- `%group` is a reference to a given resource itself
+- `%app` is a reference to an application, hosted on `ship`, located at `desk`, with a `path` that the receiving application can use to link to some content (this is just `/` when unused).
+
+`content` enumerates all the possible content types that a post can have. The possible content types can be:
+
+- **Text** - representing plain text content
+- **Url** - specific data type for urls
+- **Mention** - mentioning another ship
+- **Code** - a pair of a piece of code that was executed and its result (static data, no execution takes place inside of Graph Store)
+- **Reference** - a reference to another post, using the `reference` type
+
+Currently, these are the only content types supported by Graph Store.
+
+### Post
+
+```hoon
++$  post
+  $:  author=ship
+      =index
+      time-sent=time
+      contents=(list content)
+      hash=(unit hash)
+      =signatures
+  ==
+::
++$  indexed-post  [a=atom p=post]
+```
+
+Post is a fundamental type that represents what we normally think of as a post on social media. Most of the rest of the types are self-explanatory. `hash` is the optional hash of the post, and `signatures` is the (potentially empty) set of `signature`s if the post is cryptographically signed.
+
+An `indexed-post` is a post with an associated index fragment that can be used to validate a post's index with an index fragment that is expected at the end of the index list.
+
+### Hashing (Part 2)
+
+```hoon
++$  validated-portion
+  $:  parent-hash=(unit hash)
+      author=ship
+      time-sent=time
+      contents=(list content)
+  ==
+::
+```
+
+The parts of a `post` that are actually hashed to obtain a value of type the earlier type `hash`.
+
+## Graph Store
+
+Here's `sur/graph-store.hoon`
+
+```hoon
++$  graph         ((mop atom node) gth)
++$  marked-graph  [p=graph q=(unit mark)]
+::
++$  maybe-post    (each post hash)
++$  node          [post=maybe-post children=internal-graph]
++$  graphs        (map resource marked-graph)
+::
++$  tag-queries   (jug term uid)
+::
++$  update-log    ((mop time logged-update) gth)
++$  update-logs   (map resource update-log)
+::
++$  internal-graph
+  $~  [%empty ~]
+  $%  [%graph p=graph]
+      [%empty ~]
+  ==
+::
++$  network
+  $:  =graphs
+      =tag-queries
+      =update-logs
+      archive=graphs
+      ~
+  ==
+::
++$  update  [p=time q=action]
+::
++$  logged-update  [p=time q=logged-action]
+::
++$  logged-action
+  $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+      [%add-nodes =resource nodes=(map index node)]
+      [%remove-posts =resource indices=(set index)]
+      [%add-signatures =uid =signatures]
+      [%remove-signatures =uid =signatures]
+  ==
+::
++$  action
+  $%  logged-action
+      [%remove-graph =resource]
+    ::
+      [%add-tag =term =uid]
+      [%remove-tag =term =uid]
+    ::
+      [%archive-graph =resource]
+      [%unarchive-graph =resource]
+      [%run-updates =resource =update-log]
+    ::
+    ::  NOTE: cannot be sent as pokes
+    ::
+      [%keys =resources]
+      [%tags tags=(set term)]
+      [%tag-queries =tag-queries]
+  ==
+::
++$  permissions
+  [admin=permission-level writer=permission-level reader=permission-level]
+::
+::  $permission-level:  levels of permissions in increasing order
+::
+::    %no: May not add/remove node
+::    %self: May only nodes beneath nodes that were added by
+::      the same pilot, may remove nodes that the pilot 'owns'
+::    %yes: May add a node or remove node
++$  permission-level
+  ?(%no %self %yes)
+```
+
+
+### Graph, Node, and Related Objects
+
+```hoon
++$  graph         ((mop atom node) gth)
++$  marked-graph  [p=graph q=(unit mark)]
+::
++$  node          [=post children=internal-graph]
++$  graphs        (map resource marked-graph)
+::
++$  internal-graph
+  $~  [%empty ~]
+  $%  [%graph p=graph]
+      [%empty ~]
+  ==
+::
++$  network
+  $:  =graphs
+      =tag-queries
+      =update-logs
+      archive=graphs
+      validators=(set mark)
+  ==
+::
+```
+
+A graph is a loosely interconnected set of data which can reference each other and be arbitrarily nested and interconnected. This concept is based off of the mathematical concept of a graph: a collection of nodes, and connections between nodes called edges.
+
+`graph` is a `mop`, a map which maintains ordering on its keys based on a sorting function also known as an ordered map. A graph's keys are `atom`s representing a node's index fragment and whose values are `node`s, where entries are sorted by largest valued keys first, using `gth` as the sorting function. This is the fundamental data structure used in Graph Store.
+
+Here are some helpful Wikipedia pages for more info on what this data type represents:
+
+- [Graph (abstract data type)](<https://en.wikipedia.org/wiki/Graph_(abstract_data_type)>)
+- [Graph database](https://en.wikipedia.org/wiki/Graph_database#Background)
+- [Graph (discrete mathematics)](<https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)>)
+
+`node` represents a pair of a `post` and all of its children, which is an `internal-graph`.
+
+`internal-graph` is a tagged union representing the state that children can be in. Either a `node` has children in the form of a `graph`, or does not have any and is labeled as `%empty`.
+
+`marked-graph` is the pair of a `graph` and an optionally present `mark`, which is used by Graph Store to validate a graph against the provided validator.
+
+`graphs` is a mapping between `resource`s and`marked-graph`s
+
+`network` is the highest level data structure used by Graph Store to represent all the information that the agent is aware of.
+
+### Tag Queries
+
+```hoon
++$  tag-queries   (jug term resource)
+```
+
+`tag-queries` is a mapping where the keys are `term`s and the values are a `set` of `resource`s (this pattern is called a `jug`). It is a simple tagging system that allows for various ad-hoc collections, similar to filesystem tags being used to sort different files/folders. While the type's name is `tag-queries`, there is no complex querying system as of now. Currently, you can add term/resources pairs into the tag queries, get a list of all terms in tag-queries, and get the whole `jug` out of Graph Store.
+
+### Update (Part 1)
+
+```hoon
++$  update  [p=time q=action]
+::
++$  logged-action
+  $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+      [%add-nodes =resource nodes=(map index node)]
+      [%remove-posts =resource indices=(set index)]
+      [%add-signatures =uid =signatures]
+      [%remove-signatures =uid =signatures]
+  ==
+::
++$  action
+  $%  logged-action
+      [%remove-graph =resource]
+    ::
+      [%add-tag =term =uid]
+      [%remove-tag =term =uid]
+    ::
+      [%archive-graph =resource]
+      [%unarchive-graph =resource]
+      [%run-updates =resource =update-log]
+    ::
+    ::  NOTE: cannot be sent as pokes
+    ::
+      [%keys =resources]
+      [%tags tags=(set term)]
+      [%tag-queries =tag-queries]
+  ==
+::
+```
+
+The `update` type is what is used to interact with Graph Store. It is used both to update subscribers with data (outgoing data) and to write to Graph Store itself (incoming data). All actions are meant to be sent as pokes to Graph Store in the form of a `action` (encapsulated by a `graph-update`), except for the last three actions ,`%keys`, `%tags`, and `%tag-queries`, which must be sent scry requests. All actions defined here allow you to create/read/update/delete various objects in a running Graph Store gall agent. An `action` encapsulates all `logged-action`; any `logged-action` is an `action`, but not necessarily the other way around.
+
+<!-- todo link to reference explaining pokes -->
+
+### Update (Part 2)
+
+```hoon
++$  update-log    ((mop time logged-update) gth)
++$  update-logs   (map resource update-log)
+::
+::
++$  logged-update  [p=time q=logged-action]
+::
+```
+
+`update-log` is an ordered map where the keys are a timestamp (time is an alias for `@da`, an absolute datetime) and the values are `logged-update`s, where entries are sorted with the most recent timestamp first. It represents a history of updates applied to a graph. `update-logs` is a mapping where keys are resources and values are `update-log`s. This is the data structure used by Graph Store to store the history of actions associated with all graphs that it knows about, where each graph has a unique resource that identifies it. A `logged-update` is a data structure that holds any `logged-update-0` along with a time identifying when the update happened. It follows a versioning pattern similar to the versioned state of a gall agent.
+
+It is important to note that the source of truth is actually the `update-logs`, and not the `graphs`. Similar to the Urbit event log, Graph Store also stores all updates that it receives, so that it can rebuild its current state on demand. The current state of the database is more of a product of the event log, like a checkpoint, or a materialized db view, and is not the source of truth. As a result, the Graph Store database is immutable in nature, where all data is preserved and deleted data is only inaccessible in the current view or checkpoint, and is still present and recoverable by replaying the log.
+
+The reason for having the main CRUD actions being `logged-update`s is so that Graph Store knows which order to process the log entries in when it is rebuilding its current state. The time associated with the `logged-update` is a way of specifying the canonical order to process operations. All other actions that aren't part of logged-update stand on their own and don't need a timestamp in order to properly apply them.
+
+### Permissions
+
+```hoon
++$  permissions
+  [admin=permission-level writer=permission-level reader=permission-level]
+::
+::  $permission-level:  levels of permissions in increasing order
+::
+::    %no: May not add/remove node
+::    %self: May only nodes beneath nodes that were added by
+::      the same pilot, may remove nodes that the pilot 'owns'
+::    %yes: May add a node or remove node
++$  permission-level
+  ?(%no %self %yes)
+```
+
+These are the types from the permissioning system explained earlier. `permissions` is just a length-3 cell of `permissions-level`s for Admins, Writers, and Readers respectively.

--- a/docs/doc/inc/garden/dev/graph-store/overview.udon
+++ b/docs/doc/inc/garden/dev/graph-store/overview.udon
@@ -1,0 +1,97 @@
+;>
+
+## Intro
+
+Graph store is a non-relational database suitable for use in building social media applications. It is primarily designed for storing text-based content and data that is generally threaded and nested. It is not suitable as a general purpose database for highly structured or pure binary data.
+
+![Graph Store Overview Diagram](https://media.urbit.org/docs/userspace/graph-store/1_graph_store_overview.svg)
+
+Graph Store is mainly in charge of two things: data storage and retrieval, and schema validation. There are two related tools: Graph Push Hook, which provides permissioning support to Graph Store and acts as a proxy layer to Graph Store for outside ships to access, and Graph Pull Hook, which can be used to request Graph Store data from other ships. Importantly, Graph Store itself does not have a built-in permissions system (or rather, is permissions-agnostic), and acts in a purely trusted manner, and assumes that all inputs are trusted. However, it only allows local, authenticated connections to communicate with it, meaning that by default, no one else on the network may modify the state of your Graph Store agent. This is why Graph Push Hook exists: to mediate untrusted requests from outside ships to your instance of Graph Store, rejecting invalid ones where a ship should not be able to modify the data.
+
+## Data Structures
+
+### Posts
+
+![Post Diagram](https://media.urbit.org/docs/userspace/graph-store/2_post_diagram.svg)
+
+Above, we can see a representation of a post on the left, along with its table form on the right.
+A post is the most basic building block of a graph.
+Every post is made up of an:
+
+- **Author** - who created the post
+- **Index** - the unique path/identifier of the post on the graph (more on this later)
+- **Time Sent** - when the post was created
+- **Contents** - data that the user intended to post
+
+Currently, Graph Store supports 5 data types for content that is to be stored within a graph:
+
+- **Text** - plain text data
+- **Url** - specific data type for urls
+- **Mention** - mentioning another ship
+- **Code** - a pair of a piece of code that was executed and its result (this is static data, and is not used to execute code on other's ships)
+- **Reference** - a reference to another post
+
+### Graphs and Nodes
+
+![Graph Node Diagram A](https://media.urbit.org/docs/userspace/graph-store/3_graph_node_diagram_a.svg)
+
+![Graph Node Diagram B](https://media.urbit.org/docs/userspace/graph-store/4_graph_node_diagram_b.svg)
+
+A graph is a flat, ordered map of nodes, where each node can have a child graph, which is itself a flat ordered map of nodes. Nodes contain a post and a child graph. In the above diagram, we can see an example of a basic graph on the top, along with the underlying structure of the data in table form underneath.
+
+A few vocab terms:
+
+- **Root graph** refers to the outermost graph, G in this case
+- **Top level** is a loose term usually used to refer to a node that exists in the root graph. **A** and **D** would be considered nodes at the top level, but **B** and all its descendants would not qualify.
+- **Sibling nodes** are two nodes that reside next to each other, meaning that they reside in the same `graph`. **A** and **D** are an example of sibling nodes.
+- We say a node is a **child** of another node if it directly resides within the child graph of that node
+- A node is a **parent** to another node if it directly contains the node within its children. An example is the relationship between **B** and **C**: **C** is a child of **B**, while **B** is the parent of **C**
+- Another way of saying a node is a child is by saying that node **B** is nested within node **A** Strictly speaking, **C** is not a child of **A**, but we do say that **A** is an **ancestor** of **C**, while **C** is a **descendant** of **A**.
+- **Leaf nodes** refer to nodes that do not have children. **C** and **D** are both examples of leaf nodes
+
+### Index
+
+![Index Diagram](https://media.urbit.org/docs/userspace/graph-store/5_index_diagram.svg)
+
+Indexes are a way of uniquely identifying a node within a graph. You can think of `index`es as similar to file paths, although they aren't exactly the same. Roughly, a file path is a unique reference to a file or folder located in the filesystem. Similarly, an index is a unique reference to a node nested within a graph. The written syntax for a full index is very similar to file paths. It consists of every index fragment in order separated by a slash. A node's **level of nesting** refers to how deeply it is nested within the context of the root graph. The level of nesting directly corresponds to the number of items in the index. An index fragment is the atom by which a node is uniquely identified within it's graph, and roughly corresponds to a specific name of a directory along a path. In the diagrams that follow, we'll use the index fragment instead of the index to avoid repeating redundant information, but please note that internally graph-store still store the full index in every node's post.
+
+In the above diagram, we would say that nodes **A** and **D** are nested 1 level deep, while **B** would be at the 2nd level of nesting, and **C** would be nested 3 levels deep.
+
+Indexes are usually numbers and are stored as such in the database. Most commonly, they can represent:
+
+- Date or time of posting
+- A sequence of numbers starting from 1 increasing
+- Structural/constant value: values which are associated with a specific meaning in the context of the schema of an application.
+
+However, there is no strict requirement for them to be numbers; they can be cords as well as other data types. As we'll see in the later sections, it is up to the app developer to decide this when creating their application.
+
+### Structural Nodes vs. Content-Centric Nodes
+
+![Structural vs Content-centric Diagram](https://media.urbit.org/docs/userspace/graph-store/6_structural_vs_content_centric_diagram.svg)
+
+When using Graph Store, there is a notion of **structural nodes** vs. **content-centric nodes**. In the example diagram, we've color coded the different nodes based on what type of node they are. **Content-centric nodes** represent data created or consumed directly by the user. **Structural nodes**, on the other hand do not directly represent user data, and instead represent a higher level relationship between different user data. Structural nodes are used to implement the structure of the schema that is being implemented. In other words, they exist away from the eyes of the user, solely for organizational purposes.
+
+Note that this differentiation between content-centric vs. structural nodes is purely developer-facing, and not encoded within the actual system. Although these patterns aren't hard or fast rules, we'll see how they can be used in practice in the validator walkthrough section.
+
+## Validator Overview - Schema and Permissions
+
+Every social application has a minimum amount of information it needs to function along with the structure that the information must follow. We'll call this the application's schema. This is enforced by a **validator**. Given a schema, a validator's primary function is to encode its constraints and validate arbitrary data against it. Graph Store uses clay marks to represent validators. Validators are a special case of a mark, so the terms will be used interchangeably.
+
+In addition, validators can also encode structural permissions. **Structural permissions** govern who is allowed to add or remove a given node (and by extension modify its children) based on the node's characteristics.
+
+There are 3 different classes of users:
+
+- **Admin** - An owner of a resource or someone who's been delegated similar privileges
+- **Writer** - Someone who can create and modify their own content but cannot modify others'
+- **Reader** - Someone who is only given permission to access but not create or modify, except in special cases
+
+There are two different types of privileges:
+
+- **Add privileges** - permission to create a given node and create any child nodes
+- **Remove privileges** - permission to remove a given node and remove any of its children
+
+There are also three different levels of access a given permission level can have:
+
+- **%no** - user does not have add or remove privileges for this node
+- **%yes** - user has add or remove privileges for this node, whether or not they authored the parent node
+- **%self** - user has add or remove privileges for child nodes only if they authored the parent node (determined by `author` of post, i.e., they are the author of the post)

--- a/docs/doc/inc/garden/dev/graph-store/reference.udon
+++ b/docs/doc/inc/garden/dev/graph-store/reference.udon
@@ -1,0 +1,240 @@
+;>
+
+## Pokes
+
+Graph Store can be poked with a `graph-update`, which can:
+
+### Add and remove a graph
+
+- `[%add-graph =resource =graph mark=(unit mark) overwrite=?]`
+
+- `[%remove-graph =resource]`
+
+### Add and remove a node
+
+- `[%add-nodes =resource nodes=(map index node)]`
+
+- `[%remove-posts =resource indices=(set index)]`
+
+### Add and remove signatures
+
+- `[%add-signatures =uid =signatures]`
+
+- `[%remove-signatures =uid =signatures]`
+
+### Add and remove tags
+
+- `[%add-tag =term =uid]`
+
+- `[%remove-tag =term =uid]`
+
+### Archive and unarchive a graph
+
+- `[%archive-graph =resource]`
+
+- `[%unarchive-graph =resource]`
+
+### Manually process an update log on a resource
+
+- `[%run-updates =resource =update-log]`
+
+## Scries
+
+What follows is a summary of the scries available in graph-store.
+
+<!-- enhancement: add examples -->
+<!-- enhancement: add refrences to relevant sections in data structures explanation -->
+
+### Export State
+
+Obtain a vase of the current state of graph-store as a noun.
+
+- Path: `/x/export`
+- Output Type: `network:store`
+
+### Fetch keys
+
+Fetch the resources of all graphs that graph-store is currently tracking.
+
+- Path: `/x/keys`
+- Output Type: `update:store`, `%keys`
+
+### Fetch tag queries
+
+Fetch the available tag queries from graph-store.
+
+- Path: `/x/tag-queries`
+- Output Type: `tag-queries`
+
+### Fetch tags
+
+Fetch all available tags from graph-store.
+
+- Path: `/x/tag-queries/tags`
+- Output Type: `(list term)`
+
+### Fetch the update log by resource
+
+This returns the full update log for the graph associated with the given resource.
+
+- Path: `/x/update-log/[ship]/[name]`
+- Inputs
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+- Output Type: `update-log:store`
+
+### Fetch time of the latest log entry by resource
+
+Fetch the time of the latest log entry by resource, if the update-log for the given resource exists.
+
+- Path: `/x/update-log/[ship]/[name]/latest`
+- Inputs
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+- Output Type: `(unit time)`
+
+### Fetch a subset of the update log
+
+- Path: `/x/update-log/[ship]/[name]/subset/[start]/[end]`
+- Inputs
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **start** and **end** (`@da`) - All logs after **start** and before **end** are to be included in the result.
+- Output Type: `update-log:store`
+
+### Fetch a specific graph by resource
+
+Returns the full graph for a given resource.
+
+- Path: `/x/graph/[ship]/[name]`
+- Inputs:
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+- Output Type: `update:store`, `%add-graph`
+
+### Request the mark of a graph
+
+Returns the mark associated a given graph, if one exists.
+
+- Path: `/x/graph/[ship]/[name]/mark`
+- Inputs:
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+- Output Type: `(unit mark)`
+
+### Request a subset of the graph
+
+Returns a subset of nodes from a graph, with or without descendants, optionally filtering for ones that fall between the start and end indexes.
+
+- Path: `/x/graph/[ship]/[name]/subset/[mode]/[start?]/[end?]`
+- Inputs:
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **mode** (`?(%kith %lone)`) - `%kith` to include descendants, `%lone` to exclude.
+  - **start** and **end** (`(unit atom)`) - Atoms used to start and end the subset. If these are unable to be parsed, the subset will start at the smallest node.
+- Output Type: `update:store` `%add-nodes`
+
+### Check if node exists
+
+Returns a flag, `%.y` if the node exists and `%.n` otherwise.
+
+- Path: `/x/graph/[ship]/[name]/node/exists/[index+]`
+- Inputs:
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **[index+]** `(list atom)`- The index of the node to check. The index should be appended to the path as a list.
+- Output Type: `flag`
+
+### Request a node
+
+Returns an `%add-nodes` update containing the node that was requested.
+
+- Path: `/x/graph/[ship]/[name]/node/index/[mode]/[index+]`
+- Inputs
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **mode** (`?(%kith %lone)`) - `%kith` to include descendants, `%lone` to exclude
+  - **[index+]** `(list atom)`- The index of the node being requested. The index should be appended to the path as a list.
+- Output Type: `update:store` `%add-nodes`
+
+### Request a node's children
+
+Returns a subset of a node's children, with or without descendants, optionally filtering for ones that fall between the start and end indexes.
+
+- Path: `/x/graph/[ship]/[name]/node/children/[mode]/[start?]/[end?]/[index+]`
+- Inputs
+
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **mode** (`?(%kith %lone)`) - `%kith` to include descendants, `%lone` to exclude.
+  - **start** and **end** (`(unit atom)`) - Atoms used to start and end the subset. If these are unable to be parsed, the subset will start at the smallest node.
+  - **[index+]** `(list atom)`- The index of the node being requested. The index should be appended to the path as a list.
+
+- Output Type: `update:store` `%add-nodes`
+
+### Request a node's siblings
+
+<!-- todo figure out behavior of %newest and %oldest -->
+
+- Path: `/x/graph/[ship]/[name]/node/siblings/[direction]/[mode]/[count]/[index+]`
+- Inputs
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **direction** (`?(%older %newer %oldest %newest)`)-
+    - `%newer` - Load the siblings with keys larger than the requested node.
+    - `%older` - Load the siblings with keys smaller than the requested node.
+    - `%newest` - Load the siblings with the largest keys.
+    - `%oldest` - Load the siblings with the largest keys.
+  - **mode** (`?(%kith %lone)`) - `%kith` to include descendants, `%lone` to exclude.
+  - **count** (`atom`) - A limit to the number of nodes to return.
+  - **[index+]** `(list atom)`- The index of the node being requested. The index should be appended to the path as a list.
+- Output Type: `update:store` `%add-nodes`
+
+### Request a node's firstborn child
+
+<!-- todo explanation -->
+
+- Path: `/x/graph/[ship]/[name]/node/firstborn/[index+]`
+- Inputs:
+
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **[index+]** `(list atom)`- The index of the node being requested. The index should be appended to the path as a list.
+
+- Output: `update:store` `%add-nodes`
+
+### Request nodes, depth first
+
+- Path: `/x/graph/[ship]/[name]/depth-first/[count]/[start]`
+- Mark: `%graph-update-3`
+- Input
+
+  - **ship** (`ship`) - The ship of the resource.
+  - **name** (`@tas`) - The name of the resource.
+  - **count** (`(unit atom)`) - A limit to the number of nodes to return.
+  - **start** (`(unit atom)`) - The index fragment to start at.
+
+- Output Type: `update:store` `%add-nodes`
+
+## Agent State
+
+The following is the definition of the agent state, known as `network`.
+
+```hoon
++$  network
+  $:  =graphs
+      =tag-queries
+      =update-logs
+      archive=graphs
+      ~
+  ==
+```
+
+Briefly,
+
+- `graphs` represents all graphs that graph store is aware of an is storing data about.
+- `tag-queries` is how graph store implements its tagging system, and uses it to keep track of associations between tags and the respective index.
+- `update-logs` is where graph-store stores the update-log that backs each graph, keyed by resource. <!-- refrence to advanced section talking about how this is the source of truth -->
+- `archive` is where graph-store stores archived graphs. These are graphs which can no longer be updated through `%run-updates`. <!-- this nuance should/could also be present in the advanced info -->
+
+For more information on these types, please take a look at the [data structure overview](/docs/userspace/graph-store/data-structure-overview).

--- a/docs/doc/inc/garden/dev/graph-store/sample-application-overview.udon
+++ b/docs/doc/inc/garden/dev/graph-store/sample-application-overview.udon
@@ -1,0 +1,363 @@
+;>
+
+Library is a sample social media application in which you can create a collection of books, called a library, which can contain any number of books.
+You can share individual collections per-ship. The creator of the collection has de-facto admin powers; he is the only one who can add or remove books to/from the library,
+remove the library itself, and add comments or remove anyone's comments. Guest ships may request access to specific libraries, which if granted,
+allows them to request any book from the library.
+
+Using this application, you can:
+
+- Create libraries, where a library is a collection of books
+- Add and remove books from a library, if you are the owner
+- Allow others to view your library based on various permissioning schemes (policies)
+- Add and remove comments from a library, if you are the owner or were granted access
+
+## Prerequisites
+
+This overview is a companion document to the _Library_ application, and assumes you are familiar with `%graph-store`. Before continuing, **you must familiarize yourself with the sample application**, which can be found [here](https://github.com/ynx0/library). See the [detailed usage guide](https://github.com/ynx0/library/blob/master/README.md) for download and installation instructions.
+
+## Project Structure
+
+Here is the directory structure of our app.
+
+```
+├── app
+│   └── library-proxy.hoon
+├── lib
+│   └── library.hoon
+├── mar
+│   ├── graph
+│   │   └── validator
+│   │       └── library.hoon
+│   └── library
+│       ├── action.hoon
+│       ├── command.hoon
+│       └── response.hoon
+├── sur
+│   └── library.hoon
+└── install.sh
+```
+
+- The main code of the application lives in [`app/library-proxy.hoon`](https://github.com/ynx0/library/blob/master/app/library-proxy.hoon). This contains the gall agent which proxies the `%graph-store` updates between ships.
+
+- [`lib/library.hoon`](https://github.com/ynx0/library/blob/master/lib/library.hoon) contains miscellaneous helper arms which the proxy uses extensively. It mainly contains arms that construct different `%graph-store` updates various actions that a user performed.
+
+- The `mar/library` folder contains the definitions of the pokes that `%library-proxy` uses.
+
+- Contained in [`mar/graph/validator/library.hoon`](https://github.com/ynx0/library/blob/master/mar/graph/validator/library.hoon) is the definition of the validation logic that `%graph-store` uses to enforce the schema of the library applications graph data.
+
+- [`sur/library.hoon`](https://github.com/ynx0/library/blob/master/sur/library.hoon) contains all the various type definitions used by `%library-store`.
+
+- [`install.sh`](https://github.com/ynx0/library/blob/master/install.sh) is a script that automates copying the source files into a ship's pier / home desk.
+
+## Implementation Summary
+
+The project contains a custom `%graph-store` validator tht specifies the application's schema and a custom gall agent, called `%library-proxy`, which sends `%graph-store` updates between the host ship and subscribers.
+The gall agent also generates `%graph-store` updates based on commands and actions that a user issues. Commands can only be issued to a proxy by the ship owner,
+while actions can be issued by any ship, but may fail based on permissions. A host ship's `%library-proxy` talks to the subscriber ship's `%library-proxy` through the normal gall app channels (pokes/peeks)
+to send them any updates that have taken place on the library graph. It is the host's responsibility to forward all relevant updates to subscribers
+(kept track of in a data structure defined [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/sur/library.hoon#L14-L15)),
+while subscribers must only trust graph updates that it receives from the owner of that resource.
+
+Here are the proxy's responsibilities:
+
+- **Application-specific API** - presents an interface for a user to interact with both his/her own library proxy and others' by directly defining and implementing a user-facing API as pokes and scries,
+  as opposed to forcing the user to deal with the graph-store API directly. The `command`/`action`/`response` poke types are defined [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/sur/library.hoon#L17-L42),
+  while the scries are defined [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L132).
+- **Graph store update creation** - creates the appropriate graph update for a given user-facing action
+- **Graph store update proxying** - handles the networking and subscription logic required to send graph store updates between host and subscriber
+- **Access control** - allows or denies ships access to libraries, checks for proper permissions before processing a `command` or `action`
+
+## Interaction with `%graph-store`
+
+There are a couple of ways that our application uses and interacts with `%graph-store`.
+Firstly, the app subscribes to `%graph-store` in `+on-init` on path `/updates`, meaning it will be notified of every single `graph-update` that occurs on the local ship. (_Recall the type of `graph-update`, defined [here](https://github.com/urbit/urbit/blob/ceed4b78d068d7cb70350b3cd04e7525df1c7e2d/pkg/arvo/sur/graph-store.hoon#L29), the reference for which can be found [here](https://urbit.org/docs/userspace/graph-store/data-structure-overview/#update-part-1)_). We also define a validator for our application that `%graph-store` uses for every _Library_ graph. Since `%graph-store` registers all validators under the path `%/graph/validator/<name of app>/hoon`, we don't have to do anything special to register our validator. We just need to correctly name our file, and provide an `+graph-indexed-post` arm which should perform all schema validation.
+
+### Synchronizing Graphs Between Ships
+
+An owner is responsible for forwarding any updates to clients. Whenever the `%library-proxy` gall agent receives an update from it's local `%graph-store`, it checks to see whether it's for a graph it owns or not. If it's not, we skip sending out updates since we don't own the resource\*. If it is, then we generate cards to poke each subscriber with that same `graph-update`. This logic occurs within the agent's `+on-watch` arm, with the logic residing in the `handle-outgoing-graph-update` arm, found [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L345).
+
+On the receiving end, since we know that we are not the source of the `graph-update`, we handle the update in the `handle-incoming-graph-store` helper arm, which makes sure to only process and forward graph store updates to local graph store that are sent by the owner, and no one else. Once it passes this permissions check, it is poked into the local graph like any other graph-update.
+
+\*_One could imagine a gossip style protocol where the data is like a fact so it doesn't matter where it came from, but in this app the library host is defined as the source of truth._
+
+## Data Model
+
+There are two main application-side data structures that we define.
+The first type is [`book`](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/sur/library.hoon#L4-L9) which contains a title and an isbn.
+The second type is a [`comment`](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/sur/library.hoon#L3), which is just a simple string of text,
+meant to represent a comment on any given book.
+
+### Representing Data using `%graph-store`
+
+The data types we defined for our application do not fit within `%graph-store` out of the box. `%graph-store` doesn't allow arbitrarily typed data in a node's content field, so we create an ad-hoc representation that we can cleanly convert to and from our own data types and `%graph-store` types.
+
+Here is the conversion code: [(link)](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/lib/library.hoon#L12-L19)
+
+```
+++  make-meta-contents
+  |=  [=book:library]
+  ^-  (list content)
+  ~[[%text title.book] [%text isbn.book]]
+++  make-comment-contents
+  |=  [comment-text=comment:library]
+  ^-  (list content)
+  ~[[%text comment-text]]
+```
+
+Each arm takes in either a `book` or a `comment`, our application specific data type, and spits out a `(list content)`, which is the type that a `node` uses to store its content.
+
+### Organizing Data within `%graph-store`
+
+We define 3 core structures:
+
+- **Library** - The fundamental data structure. A library is a graph that contains books
+- **Book** - A data structure that contains an entry of a given book's metadata (i.e. title and isbn) and any comments associated with it. It is represented by a top-level node within a library graph
+- **Comment** - A node that represents a user's comment on a given book. Represented as a child node of a book's comment container node.
+
+We then define the layout of the data as follows:
+
+- Library
+  - Book
+    - Metadata Revision Container
+      - Specific Metadata Revision
+    - Comments Container
+      - Specific Comment
+
+Every graph created with the `%graph-validator-library` is a _Library_ graph, and thus it has the following characteristics:
+
+- Every Library graph represents a library, or a collection of books
+- Every top level node in a library represents a book and all related contents
+- Within a book there are always two structural nodes: a container node for metadata revisions, and a container node that holds all comments, modeling a comments section
+
+To make things more concrete, let's look at an example of an actual graph.
+
+(_For the sake of clarity, we have replaced each index with its representation in its original aura in following output._)
+
+```
+[ p=[entity=~zod name=%library1]
+    q
+  [   p
+    { [ key=~2021.6.27..14.18.57..b3dc
+          val
+        [   post
+          [ %.y
+              p
+            [ author=~zod
+              index=~[~2021.6.27..14.18.57..b3dc]
+              time-sent=~2021.6.27..14.18.57..b3dc
+              contents=~
+              hash=~
+              signatures={}
+            ]
+          ]
+            children
+          [ %graph
+              p
+            { [ key=%comments
+                  val
+                [   post
+                  [ %.y
+                      p
+                    [ author=~zod
+                      index=~[~2021.6.27..14.18.57..b3dc %comments]
+                      time-sent=~2021.6.27..14.18.57..b3dc
+                      contents=~
+                      hash=~
+                      signatures={}
+                    ]
+                  ]
+                  children
+                  [ %graph
+                          p
+                        { [ key=~2021.6.27..14.20.00.b5fc
+                          val
+                        [   post
+                          [ %.y
+                              p
+                            [ author=~pub
+                              index=~[~2021.6.27..14.18.57..b3dc %meta ~2021.6.27..14.20.00.b5fc]
+                              time-sent=~2021.6.27..14.20.00.b5fc
+                              contents=~[[%text text='dune is pretty good']]
+                              hash=~
+                              signatures={}
+                            ]
+                          ]
+                          children=[%empty ~]
+                        ]
+                      ]
+                        }
+                  ]
+                ]
+              ]
+              [ key=%meta
+                  val
+                [   post
+                  [ %.y
+                      p
+                    [ author=~zod
+                      index=~[~2021.6.27..14.18.57..b3dc %meta]
+                      time-sent=~2021.6.27..14.18.57..b3dc
+                      contents=~
+                      hash=~
+                      signatures={}
+                    ]
+                  ]
+                    children
+                  [ %graph
+                      p
+                    { [ key=2
+                          val
+                        [   post
+                          [ %.y
+                              p
+                            [ author=~zod
+                              index=~[~2021.6.27..14.18.57..b3dc %meta 1]
+                              time-sent=~2021.6.27..14.18.58..a4ed
+                              contents=~[[%text text='Dune'] [%text text='0441172717']]
+                              hash=~
+                              signatures={}
+                            ]
+                          ]
+                          children=[%empty ~]
+                        ]
+                      ]
+                      [ key=1
+                          val
+                        [   post
+                          [ %.y
+                              p
+                            [ author=~zod
+                              index=~[~2021.6.27..14.18.57..b3dc %meta 1]
+                              time-sent=~2021.6.27..14.18.57..b3dc
+                              contents=~[[%text text='Dune......'] [%text text='0444444444']]
+                              hash=~
+                              signatures={}
+                            ]
+                          ]
+                          children=[%empty ~]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              ]
+            }
+          ]
+        ]
+      ]
+    }
+    q=[~ %graph-validator-library]
+  ]
+]
+```
+
+![Library App Schema Diagram](https://media.urbit.org/docs/userspace/graph-store/library-app-schema-diagram.svg)
+
+- The above graph represents a library that has a single book, whose metadata is stored under the `%meta` revision container. The metadata associated with this specific book entry is currently with title: `"Dune"` and isbn `"0441172717"`.
+  The reason we have a revision container for the book metadata is so that in case someone makes an error, they may correct it. A potential frontend could then simply show the most recent version.
+- Each comment is simply a node under a book's `%comment` node with a single `%text` content.
+  We skipped revision containers for comments to keep schema simple, but you could imagine duplicating the same logic for comments as well.
+- Every book node has an index the datetime of when it was created.
+- Each structural node in a book has a constant index fragment, either `%meta` for the metadata revision container node,
+  or `%comments` for the comments container node.
+- Every comment has an index of the datetime of when it was posted.
+- The metadata revisions are a single incrementing number starting from 1, so the initial metadata has a revision count of `1`, and a subsequent edit has a revision count of `2`, and so on.
+
+### Schema Enforcement
+
+Recall that when using `%graph-store`, all data that is to be added to a graph passes through our [custom validator](https://github.com/ynx0/library/blob/master/mar/graph/validator/library.hoon).
+Take a moment to read through it and cross-check your understanding with the following summary.
+
+**Validator logic summary**
+
+- None of the structural nodes require data, so we simply assert that their contents are empty
+- For a _Specific Comment Node_, a post with an index matching the structure `[@ %comments @ ~]`, we assert that `contents` only contains a single `%text` content.
+  This choice is arbitrary but meant to keep the application simple and so that a potential frontend does not have to do complex rendering.
+- For a _Specific Metadata Revision_, a post with index matching the structure `[@ %meta @ ~]`, we first ensure that it's contents only contain two `%text` content instances.
+  We then use two helper arms `+is-title-valid` and `+is-isbn-valid` to validate the two values. For us, any title value is accepted, while only strings with length 10 or 13 are valid ISBNs.
+  (We don't do any true ISBN validation for simplicity's sake)
+
+## Access Control
+
+### Rules
+
+There are explicit access control rules called `policy`s, (defined [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/sur/library.hoon#L45-L49))
+which are set by the user per-library at the time of creation (stored [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L179)).
+These specify who can or cannot gain access to a library.
+
+Here's what `policy` looks like:
+
+```
++$  policy
+  $%  [%open ~]                      ::  any ship is allowed
+      [%children ~]                  ::  any children (i.e. moons) are allowed
+      [%whitelist ships=(set ship)]  ::  any ships in the provided set are allowed
+  ==
+```
+
+There are also implicit rules, defined as follows:
+
+For any given library that one owns,
+
+- An owner can:
+  - add a top level book node to any library
+  - add a metadata revision to any book
+  - add or remove any comment on any book
+- A reader, that is, a another ship granted access to the library, can:
+  - add a comment to any book that they have requested
+  - remove any comment that they are the author of
+
+Implicitly, all readers are given permission to get any book when granted access to the library.
+
+### Implementation
+
+- `policies` is a `(map @tas policy)`. That is, a map between the names of libraries that we own and what policy should be enforced on each one and is a part of the agent state (shown [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L13)).
+
+- The `+is-allowed` arm, (found [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/lib/library.hoon#L21))
+  implements each `policy`'s behavior, and is reproduced below.
+
+  ```
+  ++  is-allowed
+    |=  [requester=ship host=ship =policy:library]
+    ^-  ?
+    ?:  =(requester host)  :: host is always allowed
+      %.y
+    ?-  -.policy
+        %open       %.y
+        %children   (team:title host requester)
+        %whitelist  (~(has in ships.policy) requester)
+    ==
+  ```
+
+  Given the host ship of a resource and the policy to be enforced for a resource, `+is-allowed` returns a boolean for whether or not a requesting ship should be allowed access to that resource.
+
+- `+is-allowed` is used in `+on-watch` [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L113), where it only allows a ship to subscribe to a library if it passes the permissions check.
+- It is also used [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L299) and [here](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L310), so that when a ship wants to know about what libraries and books exist, only data they are allowed to see gets revealed to them.
+- Some of the more ad-hoc/implicit permission rules are implemented at the following locations: [[1](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L318) [2](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L48) [3](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L256) [4](https://github.com/ynx0/library/blob/9104145bb24e8ec949a5e9685139665b07161dd6/app/library-proxy.hoon#L299)]
+
+## Alternative Methods
+
+There are a number of architectural decisions made in our application that may not be suitable for other projects.
+Many decisions made such as the definition of the schema, the user-facing and inter-proxy API, and the permissioning model could be done differently.
+For instance, many decisions in the schema and thus the validator were made to keep the schema simple. One could imagine allowing any content type and amount,
+while right now it is restricted to a single text content, and stricter validation of or a custom for the ISBN.
+The subscription model is also just one way to handle subscriptions and by no means the only one.
+The permissioning scheme was also implemented relatively simple; it has some limitations, like the fact that you cannot change the permissions after creating the a library, or the fact that there are only 3 policy types.
+
+### Comparison between `%library-proxy` and `%graph-push-hook`
+
+`%library-proxy` performs the functions of both `%graph-push-hook` and `%graph-pull-hook`.
+`%graph-pull-hook` is responsible for asking other `%graph-push-hook`s for graph data
+by trying to initiate a subscription on the host ship's `%graph-push-hook`, which the host only allows if they have permissions.
+When it succeeds, `%graph-push-hook` then sends out all `graph-updates` to those subscribers who need to hear about it.
+`%graph-pull-hook` then merges in graph updates it hears into the local `%graph-store`.
+So far, all the functionality is in line with `%library-proxy`.
+
+The two main places where the hooks differ is in their choice of permissioning model and subscription model.
+To know whether a person is allowed to access a resource, pull hook uses checks to see whether they are a member of a group, while `%library-proxy` uses its own policy type.
+For subscriptions, the hooks do it per-resource, (i.e. one subscription path per resource, many ships subscribe to that),
+while library proxy incorporates both the resource and the ship in its path, making the subscription model per-resource per-ship.
+
+In general, if your application's use case does not fall neatly with the permissioning and subscription model used by the hooks, you'll need to make your own proxy agent.
+Otherwise, you will likely want to use the existing hooks and save yourself the trouble of reimplementing all of the functionality that they offer.

--- a/docs/doc/inc/garden/dev/graph-store/validator-walkthrough.udon
+++ b/docs/doc/inc/garden/dev/graph-store/validator-walkthrough.udon
@@ -1,0 +1,470 @@
+;>
+
+## Schema and Permissioning Implementation
+
+In this section, we will analyze various applications and see how they implement their schema and permissions.
+
+### Current State of Permissioning
+
+Please note that as it stands today, the current permissioning system is likely subject to change. It is by no means the only manner in which to set up permissionings. For many applications, writing a small and bespoke permissioning library may be suitable as an alternative to the `graph-push-hook` permissioning scheme which is what will be covered in the following examples.
+
+Also, please be aware that the current set of applications use a special type known as `vip-metadata`, which stands for "variation in permission".
+It is extra metadata attached to a post that is available to the permissioning arms that is mainly used to specify whether reader comments are enabled or disabled.
+Here's the source if you want to explore: [`sur/metadata-store.hoon#L20-L30`](https://github.com/urbit/urbit/blob/ac096d85ae847fcfe8786b51039c92c69abc006e/pkg/arvo/sur/metadata-store.hoon#L20-L30)
+
+### Chat
+
+#### Schema
+
+Here's what the schema of chat looks like:
+
+![Chat Schema Diagram](https://media.urbit.org/docs/userspace/graph-store/7_chat_schema_diagram.svg)
+
+A chat is a flat graph, where all chat messages are nodes appended to the root of the graph.
+The graph represents a chat channel and contains all chat messages in order. A chat message is a child node of the root graph.
+
+Here's the definition of the schema in the chat validator mark:
+File: [`mar/graph/validator/chat.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/chat.hoon#L33-L40)
+
+```hoon
+++  grab
+  |%
+  ++  noun
+    |=  p=*                     :: 1
+    =/  ip  ;;(indexed-post p)  :: 2
+    ?>  ?=([@ ~] index.p.ip)    :: 3
+    ip                          :: 4
+  --
+::
+```
+
+Here are the steps:
+
+1. Given a noun (we expect an indexed-post)
+1. Try to coerce p to an indexed-post, crash if it doesn't cast
+1. Assert that the index of the post of the indexed post is only a single atom, i.e., that it is only nested one level deep
+1. Return the indexed post
+
+Notably, under this set of rules, there is no nesting allowed. Put another way, no node is allowed to have any children. Nodes can only be added to the root graph. Step 3 is what enforces the flat hierarchy. If someone were to manually try to submit a node with children, Graph Store would reject it, preventing them from sending an invalid chat message.
+
+Since the schema of the chat application is simple enough, it has no need for structural nodes at all.
+
+#### Permissioning
+
+![Chat Permissions Diagram](https://media.urbit.org/docs/userspace/graph-store/8_chat_permissions_diagram.svg)
+
+Let's take a look at the permissions table in the diagram.
+
+Chat Message `[@ ~]`
+
+- Add Privileges
+  - Admins and Writers have `%yes` add permissions for all nodes at the top level, meaning that they have the ability to post chat messages, even if they did not create the chat channel
+  - Readers have `%no` add privileges for any nodes at the root level, so they do not have the ability to post chat messages
+- Remove Privileges
+  - Admins and Writers have `%self` remove privileges, meaning that they may only delete chat messages that they posted, not anyone else's
+  - Readers have `%no` remove privileges for any nodes, meaning they cannot delete any chat messages
+
+This follows our general intuition of how permissions for chat messages should be structured.
+For example, it wouldn't make sense to give readers `%self`, because they do not have the ability to create nodes in the first place, so they will never be in a position to delete any nodes.
+
+Let's see how this permissioning system is implemented in the validator code.
+
+Here is the `grow` arm of [`mar/validator/chat.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/chat.hoon#L7-L20)
+
+```hoon
+|_  i=indexed-post              :: A
+++  grow
+  |%
+  ++  graph-permissions-add
+    |=  vip=vip-metadata:met    :: 1
+    ?+  index.p.i  !!           :: 2
+      [@ ~]  [%yes %yes %no]    :: 3
+    ==
+  ::
+  ++  graph-permissions-remove
+    |=  vip=vip-metadata:met    :: 4
+    ?+  index.p.i  !!           :: 5
+      [@ ~]  [%self %self %no]  :: 6
+    ==
+  ::
+  --
+::
+```
+
+In line A, we accept an `indexed-post` that is used in the rest of the `grow` arm.
+
+`graph-permissions-add`
+
+1. Accept a noun `vip` of type `vip-metadata`
+2. Switch on the index of the post found in `i`, crashing if no successful matches occur
+3. If the index is nested one level deep
+4. Return a `permissions` noun defined as: [admin: %yes, writer: %yes, reader: %no]
+
+   `graph-permissions-remove`
+
+5. Accept a noun `vip` of type vip-metadata
+6. Switch on the index, crashing if no successful matches occur
+7. If the index is nested one level deep
+8. Return a `permissions` noun defined as: [admin: %self, writer: %self, reader: %no]
+
+In this example, a switch statement is used to determine the `permissions` values based on the index of the post.
+
+### Links
+
+#### Schema
+
+![Link Schema Diagram](https://media.urbit.org/docs/userspace/graph-store/9_link_schema_diagram.svg)
+
+The root graph represents the whole Links collection. Every Links entry is a child node of this graph. Every Links entry is made up of:
+
+- The link and its description
+- A comments section
+
+The comments section holds all individual comment nodes, but comments are not simple leaf nodes. An individual comment is actually a structural node that acts as a revision container, storing the comment's full edit history by storing each edit as a child node. The front-end is responsible for properly displaying the latest revision of the comment.
+
+Here's the validator, located at [`mar/graph/validator/link.hoon`](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/link.hoon#L49-L73):
+
+```hoon
+++  grab
+  |%
+  ++  noun
+    |=  p=*                                         :: 1
+    =/  ip  ;;(indexed-post p)                      :: 2
+    ?+    index.p.ip  ~|(index+index.p.ip !!)       :: 3
+        ::  top-level link post; title and url
+        ::
+        [@ ~]                                       :: 4
+      ?>  ?=([[%text @] [%url @] ~] contents.p.ip)  :: 4a
+      ip
+    ::
+        ::  comment on link post; container structure
+        ::
+        [@ @ ~]                                     :: 5
+      ?>  ?=(~ contents.p.ip)                       :: 5a
+      ip
+    ::
+        ::  comment on link post; comment text
+        ::
+        [@ @ @ ~]                                   :: 6
+      ?>  ?=(^ contents.p.ip)                       :: 6a
+      ip
+    ==
+  --
+```
+
+<ol>
+  <li>Get the post as a noun</li>
+  <li>Force cast to indexed post</li>
+  <li>
+    Switch on index of post, crash if no match occurs
+    <ol type="a">
+      <li>If the node is nested one level deep, (if the index is made up of a single atom)</li>
+      <li>Ensure that it is a cell that has two pieces of data, whose content types are text and url</li>
+      <li>If the node is nested two levels deep</li>
+      <li>Ensure that it is empty, this is the structural node for holding comment revisions; it should not contain any content</li>
+    </ol>
+  </li>
+  <li>
+    If the node is nested three levels deep
+    <ol type="a">
+      <li>Ensure that it is a cell, this is a specific revision of a comment under a revision container</li>
+    </ol>
+  </li>
+</ol>
+
+It is important to note that you cannot directly edit the url or link afterwards, only the whole link entry itself. This is because you can only add or remove nodes to a graph, not modify them. Comments, however, can be “edited”. This is possible by using a technique called a revision container. Instead of having a single leaf node holding the comment text in its contents, a node with empty contents is created. All revisions of the comment are added as children to this note, and the frontend simply shows the most recent one only.
+
+#### Permissioning
+
+![Links Permissions Diagram A](https://media.urbit.org/docs/userspace/graph-store/10_links_permissions_diagram_a.svg)
+
+![Links Permissions Diagram B](https://media.urbit.org/docs/userspace/graph-store/11_links_permissions_diagram_b.svg)
+
+Let's analyze the permissions structure.
+
+**TODO** _stubbed out awaiting potential changes in source_
+
+Here's how it is implemented [(source)](https://github.com/urbit/urbit/blob/master/pkg/arvo/mar/graph/validator/link.hoon#L2-L27):
+
+```hoon
+|_  i=indexed-post
+++  grow
+  |%
+  ++  noun  i
+  ::
+  ++  graph-permissions-add
+    |=  vip=vip-metadata:met                      :: 1
+    =/  reader                                    :: 2
+      ?=(%reader-comments vip)
+    ?+  index.p.i  !!                             :: 3
+      [@ ~]       [%yes %yes %no]                 :: 3a
+      [@ @ ~]     [%yes %yes ?:(reader %yes %no)] :: 3b
+      [@ @ @ ~]   [%self %self %self]             :: 3c
+    ==
+  ::
+  ++  graph-permissions-remove
+    |=  vip=vip-metadata:met                      :: 4
+    =/  reader                                    :: 5
+      ?=(%reader-comments vip)
+    ?+  index.p.i  !!                             :: 6
+      [@ ~]       [%yes %self %self]              :: 6a
+      [@ @ ~]     [%yes %self %self]              ::
+      [@ @ @ ~]   [%yes %self %self]              ::
+    ==
+  ::
+```
+
+`graph-permissions-add`
+
+<ol>
+    <li>Accept a noun <code>vip</code> of type vip-metadata
+        <ul>
+            <li>Declare a variable <code>reader</code>, a flag which is true if reader comments are enabled, false otherwise</li>
+        </ul>
+    </li>
+    <li>Switch on the index of the post found in <code>i</code>, crashing if no successful matches occur</li>
+    <li>If the index is nested one level deep, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%yes</code></li>
+    <li>Reader: <code>%no</code></li>
+        </ul>
+    </li>
+    <li>If the index is nested two levels deep, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%yes</code></li>
+    <li>Reader: <code>%yes</code> if reader comments are enabled, else <code>%no</code></li>
+        </ul>
+    </li>
+    <li>If the index is nested three levels deep, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%yes</code></li>
+    <li>Reader: <code>%yes</code> if reader comments are enabled, else <code>%no</code></li>
+        </ul>
+    </li>
+</ol>
+
+`graph-permissions-remove`
+
+<ol>
+    <li>Accept a noun <code>vip</code> of type vip-metadata</li>
+    <li>Declare a variable <code>reader</code>, a flag which is true if reader comments are enabled, false otherwise</li>
+    <li>Switch on the index of the post found in <code>i</code>, crashing if no successful matches occur</li>
+    <li>If the index is nested one level deep, two levels deep, or three levels deep, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%self</code></li>
+    <li>Reader: <code>%self</code></li>
+        </ul>
+    </li>
+</ol>
+
+### Publish
+
+#### Schema
+
+![Publish Schema Diagram](https://media.urbit.org/docs/userspace/graph-store/12_publish_schema_diagram.svg)
+
+Here, a notebook, which is a collection of blog posts (called notes), is represented by the root graph. All data associated with the blog post is represented by the top level node, which is the note itself along with the associated comments. One level deeper, we see two container structures. The first one is the post revision container; it holds the edit history of your blog post. Every child node of this corresponds to the actual title and text of your blog post. The second one is the comments container. This represents the comment section of your blog post. Every child node of this is not a comment, but a comment revision container, which, as before, contains the edit history of your comment.
+
+Here's its validator, located at [`mar/graph/validator.hoon`](https://github.com/urbit/urbit/blob/master/pkg/arvo/mar/graph/validator/publish.hoon#L56-L97)
+
+```hoon
+  ++  noun
+    |=  p=*                            :: 1
+    =/  ip  ;;(indexed-post p)         :: 2
+    ?+    index.p.ip  !!               :: 3
+    ::  top level post must have no content
+        [@ ~]                          :: 4
+      ?>  ?=(~ contents.p.ip)          :: 4a
+      ip
+    ::  container for revisions
+    ::
+        [@ %1 ~]                       :: 5
+      ?>  ?=(~ contents.p.ip)          :: 5a
+      ip
+    ::  specific revision
+    ::  first content is the title
+    ::  revisions are numbered by the revision count
+    ::  starting at one
+        [@ %1 @ ~]                     :: 6
+      ?>  ?=([* * *] contents.p.ip)    :: 6a
+      ?>  ?=(%text -.i.contents.p.ip)  :: 6b
+      ip
+    ::  container for comments
+    ::
+        [@ %2 ~]                       :: 7
+      ?>  ?=(~ contents.p.ip)          :: 7a
+      ip
+    ::  container for comment revisions
+    ::
+        [@ %2 @ ~]                     :: 8
+      ?>  ?=(~ contents.p.ip)          :: 8a
+      ip
+    ::  specific comment revision
+    ::
+        [@ %2 @ @ ~]                   :: 9
+      ?>  ?=(^ contents.p.ip)          :: 9a
+      ip
+    ==
+  --
+```
+
+Walkthrough
+
+<ol>
+  <li>Get the post as a noun</li>
+  <li>Force cast to indexed post</li>
+  <li>Switch on index of post, crashing (reject) if no matches found</li>
+  <li>If the node is nested one level deep
+    <ol type="a"><li>Ensure that its contents are empty. The top level node is a structural node containing all of the post and associated data.</li></ol>
+  </li>
+  <li>If it is nested 2 levels deep and contains a 1 as it's last index fragment
+    <ol type="a"><li>Ensure that its contents are empty. This is a structural node for holding revisions to the blog post.</li></ol>
+  </li>
+  <li>If the node is nested three levels deep, and has a 1 as it's second index fragment
+    <ol type="a">
+      <li>Ensure that its contents is a list of at least 2 elements</li>
+      <li>Ensure that the first element of contents has a content type of text</li>
+    </ol>
+  </li>
+  <li>If the node is nested two levels deep, and has a 2 as it's last index fragment
+    <ol type="a"><li>Ensure that its contents are empty. This is a structural node for holding comments.</li></ol>
+  </li>
+  <li>If the node is nested three levels deep, and has a 2 as it's second index fragment
+    <ol type="a"><li>Ensure that its contents are empty. This is a structural node for holding revisions of a specific comment.</li></ol>
+  </li>
+  <li>If the node is nested four levels deep, and has a 2 as it's second index fragment
+    <ol type="a"><li>Ensure that contents has type `cell`. This is a specific revision of a comment</li></ol>
+  </li>
+</ol>
+
+Items 1-3 are setting up the validator
+Items 4-6 are enforcing the schema for the post in general
+Items 7-9 are enforcing the schema for comments specifically
+
+Notably, the revision container for the blog post itself allows the post to be edited, unlike the link entry in the previous example. In addition, in step six, the reason that the validator is made this way is because the first element of the contents is interpreted as the title of the post, and the rest of the elements are interpreted as the body of the post. Otherwise, the structure is unchanged from the Links example.
+
+#### Permissioning
+
+![Publish Permissions Diagram A](https://media.urbit.org/docs/userspace/graph-store/13_publish_permissions_diagram_a.svg)
+
+![Publish Permissions Diagram B](https://media.urbit.org/docs/userspace/graph-store/14_publish_permissions_diagram_b.svg)
+
+Let's take a look at the permissioning structure for Publish.
+
+**TODO** _stubbed out awaiting potential changes in source_
+
+[(source)](https://github.com/urbit/urbit/blob/fbd85abf4e41d580654606a6defb764f6a97256d/pkg/arvo/mar/graph/validator/publish.hoon#L6-L24)
+
+```hoon
+|_  i=indexed-post
+++  grow
+  |%
+  ++  noun  i
+  ++  graph-permissions-add
+    |=  vip=vip-metadata:met                                              :: 1
+    ?+  index.p.i  !!                                                     :: 2
+      [@ ~]            [%yes %yes %no]  :: new note                       :: 2a
+      [@ %1 @ ~]       [%self %self %no]                                  :: 2b
+      [@ %2 @ ~]       [%yes %yes ?:(?=(%reader-comments vip) %yes %no)]  :: 2c
+      [@ %2 @ @ ~]     [%self %self %self]                                :: 2d
+    ==
+  ::
+  ++  graph-permissions-remove
+    |=  vip=vip-metadata:met                                              :: 3
+    ?+  index.p.i  !!                                                     :: 4
+      [@ ~]            [%yes %self %self]                                 :: 4a
+      [@ %1 @ @ ~]     [%yes %self %self]                                 ::
+      [@ %2 @ ~]       [%yes %self %self]                                 ::
+      [@ %2 @ @ ~]     [%yes %self %self]                                 ::
+    ==
+::
+```
+
+`graph-permissions-add`
+
+  <ol>
+    <li>Accept a noun <code>vip</code> of type vip-metadata</li>
+    <li>Switch on the index of the post found in <code>i</code>, crashing if no successful matches occur</li>
+    <li>If the index is nested one level deep, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%yes</code></li>
+    <li>Reader: <code>%no</code></li>
+        </ul>
+    </li>
+    <li>If the index is nested three levels deep and has a 1 as its 2nd index fragment, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%self</code></li>
+    <li>Writer - <code>%self</code></li>
+    <li>Reader: <code>%no</code></li>
+        </ul>
+    </li>
+    <li>If the index is nested three levels deep and has a 2 as its 2nd index fragment, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%yes</code></li>
+    <li>Writer - <code>%yes</code></li>
+    <li>Reader: <code>%yes</code> if reader comments are enabled, else <code>%no</code></li>
+        </ul>
+    </li>
+    <li>If the index is nested four levels deep and has a 2 as its 2nd index fragment, return a <code>permissions</code> noun defined as:
+        <ul>
+    <li>Admin - <code>%self</code></li>
+    <li>Writer - <code>%self</code></li>
+    <li>Reader: <code>%self</code></li>
+        </ul>
+    </li>
+</ol>
+
+`graph-permissions-remove`
+
+<ol>
+  <li>Accept a noun <code>vip</code> of type <code>vip-metadata</code></li>
+  <li>Declare a variable <code>reader</code>, a flag which is true if reader comments are enabled, false otherwise</li>
+  <li>Switch on the index of the post found in <code>i</code>, crashing if no successful matches occur</li>
+    <li>If the index is nested one level deep, two levels deep, or three levels deep, return a <code>permissions</code> noun defined as:
+        <ul>
+            <li>Admin - <code>%yes</code></li>
+      <li>Writer - <code>%self</code></li>
+      <li>Reader: <code>%self</code></li>
+        </ul>
+    </li>
+</ol>
+
+## General Patterns and Best Practices
+
+### General Patterns
+
+#### Schemas
+
+The general pattern for enforcing a schema in a validator is to:
+
+1. Cast the incoming data as an `indexed-post`
+1. Switch on the index, matching by its depth and structure
+1. Validate the structure of the contents of the post based on what we expect to see at that level of nesting. This logic can definitely be more involved than simply presence or absence of data.
+
+When designing your schema, it may help to decide first what data the user will be directly consuming or producing, then try to think of what extra information and structure is needed to support that. For instance, if you may want a user to be able to enter a comment, then later realize that you need a structural node that contains the whole comments section. One pattern that we can see is that all structural nodes tend to have empty contents. Another pattern we can see is that all leaf nodes have their contents set.
+
+In general, validators can be as robust and expressive as desired, because the mark system already sets proper limitations of what you can and cannot do, with the main restriction being no side effects can be produced by a mark.
+
+#### Permissions
+
+In general, you want to first have your schema finalized, then at every node ask the question: who should be able to modify (add/remove) this node, and its children if present in your schema. You may find that you don't need to set permission for every single type of node afterwards, although being thorough can help to find bugs in permissioning early on. Writing out the permissions in plain words and bullet points, sketching them out in the form of a table, then splitting it up into the code can also make the design process easier.
+
+### Earth/Mars Interface Details
+
+There are a few general ways to talk to a Graph Store gall agent. You can either interact with the agent in the form of pokes/scries/spiders either directly from the dojo, or through HTTP requests via Eyre.
+
+- All graph store applications are going to have a mark, which are applied to data going in or coming out
+- Eyre lets you choose the mark you scry for by specifying the desired format in the url while making the HTTP request
+- In the case of data going in, you pass in a `marked-graph` which the Graph Store agent uses to validate the whole `graph` with. In the case of adding a node to a graph, the node will simply be checked for validity using the existing mark since the mark is already set on a per-graph basis
+- In the case of data coming out, Eyre forcibly tries to convert the hoon noun into json, and silently fails if no json conversion exists. This process is handled by Graph Store under the hood because all graphs have a well-defined en-json/de-json format, so you never have to worry about making your own de/serialization arms.
+
+Code References
+
+- [`interface/src/logic/api/base.ts#L62`](https://github.com/urbit/urbit/blob/master/pkg/interface/src/logic/api/base.ts#L62)
+- [`mar/graph/update.hoon`](https://github.com/urbit/urbit/blob/e2ad6e3e9219c8bfad62f27f05c7cac94c9effa8/pkg/arvo/mar/graph/update.hoon)
+- [`sys/vane/eyre.hoon#L1617-L1625`](https://github.com/urbit/urbit/blob/ac096d85ae847fcfe8786b51039c92c69abc006e/pkg/arvo/sys/vane/eyre.hoon#L1617-L1625) shows how Eyre applies marks

--- a/docs/doc/inc/garden/doc.toc
+++ b/docs/doc/inc/garden/doc.toc
@@ -15,6 +15,6 @@
     /overview/udon    Overview
     /data-structure-overview/udon  Data Structures
     /validator-walkthrough/udon    Validator Walkthrough
-    /graph-store-reference/udon    Reference
+    /reference/udon   Reference
     /advanced-info/udon            Advanced Info
     /sample-application-overview/udon  Sample Application

--- a/docs/doc/inc/garden/doc.toc
+++ b/docs/doc/inc/garden/doc.toc
@@ -11,3 +11,10 @@
     /pokes/udon       Pokes
     /paths/udon       Subscription Paths
     /scry/udon        Scry Endpoints
+  /graph-store        Graph-store
+    /overview/udon    Overview
+    /data-structure-overview/udon  Data Structures
+    /validator-walkthrough/udon    Validator Walkthrough
+    /graph-store-reference/udon    Reference
+    /advanced-info/udon            Advanced Info
+    /sample-application-overview/udon  Sample Application


### PR DESCRIPTION
This migrates the Graph Store docs from the old urbit.org/docs site to the %docs app.