### PR TITLE
mark: remove /sur/docs dependency from /mar/toc

### DIFF
--- a/bare-desk/mar/toc.hoon
+++ b/bare-desk/mar/toc.hoon
@@ -1,4 +1,3 @@
-/-  docs
 |_  tab=@t
 ++  grab
   |%


### PR DESCRIPTION
The current version of this mark wasn't actively depending on any of the types from `/sur/docs`, so it shouldn't be importing them.

This way, the mark can trivially be imported stand-alone, for more minimalist docs distributions.