### PR TITLE
app: if absent, infer /doc/toc from /doc files

### DIFF
--- a/bare-desk/doc/dev/index-file.udon
+++ b/bare-desk/doc/dev/index-file.udon
@@ -1,6 +1,6 @@
 ;>
 
-Each desk with docs must include a `doc.toc` file in its root. A `doc.toc` file
+Each desk with docs may include a `doc.toc` file in its root. A `doc.toc` file
 looks something like this:
 
 ```
@@ -33,3 +33,6 @@ listed.
 
 The title specified will be displayed at the top of the document and in the
 table of contents for the desk.
+
+If no `doc.toc` file is included, but a desk does have other files under `/doc`, the Docs app will infer a table of contents from the directory structure, and _all_ files will be included.
+Files are ordered alphabetically, except that 'overview' always come first. For titles, hyphens in the filename are replaced with spaces and the whole is converted to Title Case.

--- a/bare-desk/doc/dev/overview.udon
+++ b/bare-desk/doc/dev/overview.udon
@@ -8,7 +8,7 @@ appropriate `mark` conversion methods, and include a
 [`doc.toc`](/docs/docs/dev/index-file) index file, they'll be
 picked up.
 
-A `doc.toc` file must be included in the root of the desk, specifying the files
+A `doc.toc` file may be included in the root of the desk, specifying the files
 to be included, their `mark`s, and their titles. See the [Index File](/docs/docs/dev/index-file) section for details.
 
 The files themselves will be in a `/doc` directory in the root of the desk. In


### PR DESCRIPTION
@tinnus-napbus as discussed out of band:

If there is no `/doc/toc` file, but there are other files under `/doc`, infer a ToC from *all* of the files under `/doc`.

Sorts 'overview' files first, but otherwise respects alphabetical ordering. Converts filenames to Title Case. Special-cases `usr` and `dev` (into "User" and "Developer" respectively, but maybe we want "User Guide"?) as per the convention given in the docs.

Proof of test case:
![image](https://github.com/tinnus-napbus/docs-app/assets/3829764/cd927973-9b0f-4d04-b8ad-ff7b8430328e)
